### PR TITLE
Create NPM Publishing Github Action Script

### DIFF
--- a/npmpublish.yml
+++ b/npmpublish.yml
@@ -1,0 +1,21 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: NPM Publishing
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISHING_TOKEN}}

--- a/npmpublish.yml
+++ b/npmpublish.yml
@@ -5,7 +5,7 @@ name: NPM Publishing
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   publish-npm:
@@ -15,7 +15,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-          registry-url: https://registry.npmjs.org/
+          registry-url: 'https://registry.npmjs.org'
+      - run: cd react/cra-template
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISHING_TOKEN}}


### PR DESCRIPTION
This PR will add a Github Action for publishing the `@developertown/cra-template` to the NPM registry.

I've created a NPM_PUBLISHING_TOKEN in the settings/secrets section.

There are no build or test steps; only a publishing step.