### PR TITLE
Updated documentation to work for PowerShell on Windows

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -5,7 +5,7 @@
 At DeveloperTown we prefer to start applications with [Create React App](https://create-react-app.dev/docs/getting-started/) and [Typescript](./languages.md)
 
 ```
-yarn create react-app `<your app name>` --template @developertown
+yarn create react-app `<your app name>` --template '@developertown'
 ```
 
 or if you want to configure everything yourself


### PR DESCRIPTION
The command to create a new project using the template needs to quote the `@` sign for PowerShell on Windows (and should be supported/compatible to other platforms as well)